### PR TITLE
connected edit, create, and delete profile thunks/actions to the bill…

### DIFF
--- a/src/components/billing/BillingView.tsx
+++ b/src/components/billing/BillingView.tsx
@@ -1,12 +1,13 @@
 import React, { FunctionComponent, useReducer, useState, useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 
 import ProfileSelector from './profileSelector/ProfileSelector'
 import PaymentDetails from './details/PaymentDetails'
 import UserDetails from './details/UserDetails'
 import AppButton from '../common/AppButton'
 import {
-  initialStore,
+  initialBillingStore,
+  initialInputErrorStore,
   billingProfileReducer,
   inputFieldErrorsReducer
 } from './store/reducers'
@@ -26,11 +27,13 @@ import {
   PaymentInfoKey
 } from './utils'
 import { RootState } from '../../store'
+import { deleteBillingProfile, createBillingProfile, updateBillingProfile } from '../../store/billingProfiles/thunks'
 
 const BillingView: FunctionComponent = () => {
-  const [store, dispatch] = useReducer(billingProfileReducer, initialStore)
-  const [inputErrors, dispatchErrors] = useReducer(inputFieldErrorsReducer, initialStore)
-  const [billingSameAsShipping, setBillingSameAsShipping] = useState(false)
+  const [store, dispatch] = useReducer(billingProfileReducer, initialBillingStore)
+  const [inputErrors, dispatchErrors] = useReducer(inputFieldErrorsReducer, initialInputErrorStore)
+
+  const rootDispatch = useDispatch()
 
   const currentProfileData = useSelector((state: RootState) => {
     const { billingProfiles } = state
@@ -44,18 +47,15 @@ const BillingView: FunctionComponent = () => {
     dispatch({
       type: POPULATE_BILLING_PROFILE, value: currentProfileData.profile
     })
+    dispatchErrors({
+      type: CLEAR_INPUT_FIELD_ERRORS_ALL
+    })
   }, [currentProfileData.currentId])
 
-  function toggleBillingMatchShipping() {
-    const previousValue = billingSameAsShipping
-    if (previousValue) {
-      setBillingSameAsShipping(false)
-    } else {
-      dispatch({
-        type: SET_SHIPPING_TO_BILLING
-      })
-      setBillingSameAsShipping(true)
-    }
+  function toggleBillingMatchShipping() { // need to remove
+    dispatch({
+      type: SET_SHIPPING_TO_BILLING
+    })
   }
 
 
@@ -64,14 +64,14 @@ const BillingView: FunctionComponent = () => {
     const paymentInfoValidationKeys = Object.keys(paymentInfoValidation)
     let areThereErrors = false
     const errorObj = {
-      billing: { ...initialStore.billing },
-      shipping: { ...initialStore.shipping },
-      payment: { ...initialStore.payment }
+      billing: { ...initialInputErrorStore.billing },
+      shipping: { ...initialInputErrorStore.shipping },
+      payment: { ...initialInputErrorStore.payment }
     }
 
     // Shipping Profile
-    if (billingSameAsShipping === false) {
-      userInfoValidationKeys.map((key: UserInfoKey) => {
+    if (store.billingSameAsShipping === false) {
+      userInfoValidationKeys.forEach((key: UserInfoKey) => {
         const validationFncs = userInfoValidation[key]
         const inputVal = store.shipping[key]
         console.log(key, inputVal)
@@ -89,7 +89,7 @@ const BillingView: FunctionComponent = () => {
     }
 
     // Billing Profile
-    userInfoValidationKeys.map((key: UserInfoKey) => {
+    userInfoValidationKeys.forEach((key: UserInfoKey) => {
       const validationFncs = userInfoValidation[key]
       const inputVal = store.billing[key]
       console.log(key, inputVal)
@@ -104,7 +104,7 @@ const BillingView: FunctionComponent = () => {
       }
     })
 
-    paymentInfoValidationKeys.map((key: PaymentInfoKey) => {
+    paymentInfoValidationKeys.forEach((key: PaymentInfoKey) => {
       const validationFncs = paymentInfoValidation[key]
       const inputVal = store.payment[key]
       console.log(key, inputVal)
@@ -123,7 +123,7 @@ const BillingView: FunctionComponent = () => {
     // If there's no errors, save profile
     if (areThereErrors === false) {
       dispatchErrors({ type: CLEAR_INPUT_FIELD_ERRORS_ALL })
-      // save profile
+      rootDispatch(updateBillingProfile(store))
     } else {
       dispatchErrors({ type: POPULATE_INPUT_FIELD_ERRORS, value: errorObj })
     }
@@ -141,11 +141,12 @@ const BillingView: FunctionComponent = () => {
           <ProfileSelector />
           <div className='mt-4 flex justify-center align-center'>
             <AppButton onClick={() => console.log('allow edit to current profile')} btnName='Edit' classes='btn-gray w-20' />
+            <AppButton onClick={() => rootDispatch(createBillingProfile())} btnName='New' classes='btn-gray w-20 ml-6' />
           </div>
         </div>
         <UserDetails name='Billing View' userDetails={store.billing} errors={inputErrors.billing} dispatch={dispatch} onChangeActionType={UPDATE_BILLING_KEY} />
         <div>
-          <UserDetails name='Shipping View' userDetails={store.shipping} errors={inputErrors.shipping} dispatch={dispatch} onChangeActionType={UPDATE_SHIPPING_KEY} billingSameAsShipping={billingSameAsShipping} />
+          <UserDetails name='Shipping View' userDetails={store.shipping} errors={inputErrors.shipping} dispatch={dispatch} onChangeActionType={UPDATE_SHIPPING_KEY} billingSameAsShipping={store.billingSameAsShipping} />
           <div>
             <input className='ml-8 mr-1' type='checkbox' name='Same as Billing Address' onChange={toggleBillingMatchShipping} />
             <label className='text-white'>Same as Billing Address</label>
@@ -155,7 +156,7 @@ const BillingView: FunctionComponent = () => {
           <PaymentDetails paymentDetails={store.payment} errors={inputErrors.payment} dispatch={dispatch} />
           <div className='flex justify-center mt-6'>
             <AppButton onClick={saveProfile} btnName='Save' classes='btn-gray mr-8 w-20' />
-            <AppButton onClick={() => console.log('Delete the currrent profile')} btnName='Delete' classes='btn-gray w-20' />
+            <AppButton onClick={() => rootDispatch(deleteBillingProfile(currentProfileData.currentId))} btnName='Delete' classes='btn-gray w-20' />
           </div>
           <div className='flex justify-center mt-4'>
             <AppButton onClick={resetProfile} btnName='Reset' classes='btn-gray mx-0 my-auto w-20' />

--- a/src/components/billing/profileSelector/ProfileInstance.tsx
+++ b/src/components/billing/profileSelector/ProfileInstance.tsx
@@ -17,7 +17,7 @@ const ProfileInstance: FunctionComponent<ProfileInstancePropTypes> = ({ profileN
       style={{ height: '30.8px' }}
       onClick={e => dispatch(changeProfile(profileId))}
     >
-      <div className='text-white text-center'>{profileName}</div>
+      <div className='text-white text-center'>{profileName || 'Unnamed Profile'}</div>
     </div >
   )
 }

--- a/src/components/billing/store/reducers.ts
+++ b/src/components/billing/store/reducers.ts
@@ -1,5 +1,6 @@
 import { BillingProfile } from '@typesTS/billingTypes'
 import { StoreAction } from './types'
+import BillingProfileFactory from '../../../factory/BillingProfile'
 
 import {
   UPDATE_BILLING_KEY,
@@ -18,48 +19,18 @@ import {
   CLEAR_BILLING_PROFILE
 } from './actions'
 
-export const initialStore: BillingProfile = {
-  id: '',
-  billing: {
-    firstName: '',
-    lastName: '',
-    address1: '',
-    address2: '',
-    city: '',
-    state: '',
-    country: '',
-    zipCode: '',
-    phone: '',
-  },
-  shipping: {
-    firstName: '',
-    lastName: '',
-    address1: '',
-    address2: '',
-    city: '',
-    state: '',
-    country: '',
-    zipCode: '',
-    phone: '',
-  },
-  payment: {
-    nameOnCard: '',
-    cardNumber: '',
-    expirationMonth: '',
-    expirationYear: '',
-    securityCode: '',
-    email: '',
-    profileName: '',
-  }
-}
+const emptyBillingProfile = BillingProfileFactory()
+export const initialBillingStore: BillingProfile = emptyBillingProfile
+export const initialInputErrorStore: Partial<BillingProfile> = emptyBillingProfile
 
-export const billingProfileReducer = (state: BillingProfile = initialStore, payload: any): BillingProfile => { // setting to any so bulk actions can be done
+export const billingProfileReducer = (state: BillingProfile = initialBillingStore, payload: any): BillingProfile => { // setting to any so bulk actions can be done
   switch (payload.type) {
     case SET_SHIPPING_TO_BILLING:
       return {
         ...state,
+        billingSameAsShipping: !state.billingSameAsShipping,
         shipping: {
-          ...initialStore.shipping
+          ...initialBillingStore.shipping
         }
       }
     case UPDATE_BILLING_KEY:
@@ -91,13 +62,13 @@ export const billingProfileReducer = (state: BillingProfile = initialStore, payl
         ...payload.value
       }
     case CLEAR_BILLING_PROFILE:
-      return initialStore
+      return initialBillingStore
     default:
       return state
   }
 }
 
-export const inputFieldErrorsReducer = (state: BillingProfile = initialStore, payload: any): BillingProfile => {
+export const inputFieldErrorsReducer = (state: Partial<BillingProfile> = initialInputErrorStore, payload: any): Partial<BillingProfile> => {
   switch (payload.type) {
     case SET_INPUT_FIELD_ERRORS_BILLING:
       return {
@@ -149,15 +120,15 @@ export const inputFieldErrorsReducer = (state: BillingProfile = initialStore, pa
       }
     case CLEAR_INPUT_FIELD_ERRORS_ALL:
       return {
-        id: initialStore.id,
+        id: initialInputErrorStore.id,
         billing: {
-          ...initialStore.billing
+          ...initialInputErrorStore.billing
         },
         shipping: {
-          ...initialStore.shipping
+          ...initialInputErrorStore.shipping
         },
         payment: {
-          ...initialStore.payment
+          ...initialInputErrorStore.payment
         }
       }
     case POPULATE_INPUT_FIELD_ERRORS:

--- a/src/factory/BillingProfile.ts
+++ b/src/factory/BillingProfile.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid'
 import { BillingProfile } from '@typesTS/billingTypes'
 
 const template = {
@@ -39,6 +40,7 @@ const template = {
 const BillingProfileFactory = (): BillingProfile => {
   return { // will definitely use lodash's deepCopy later on if we do bring in the library
     ...template,
+    id: uuidv4(),
     billing: {
       ...template.billing
     },

--- a/src/factory/BillingProfile.ts
+++ b/src/factory/BillingProfile.ts
@@ -37,7 +37,7 @@ const template = {
 }
 
 const BillingProfileFactory = (): BillingProfile => {
-  return {
+  return { // will definitely use lodash's deepCopy later on if we do bring in the library
     ...template,
     billing: {
       ...template.billing

--- a/src/factory/BillingProfile.ts
+++ b/src/factory/BillingProfile.ts
@@ -1,0 +1,54 @@
+import { BillingProfile } from '@typesTS/billingTypes'
+
+const template = {
+  id: '',
+  billingSameAsShipping: false,
+  billing: {
+    firstName: '',
+    lastName: '',
+    address1: '',
+    address2: '',
+    city: '',
+    state: '',
+    country: '',
+    zipCode: '',
+    phone: '',
+  },
+  shipping: {
+    firstName: '',
+    lastName: '',
+    address1: '',
+    address2: '',
+    city: '',
+    state: '',
+    country: '',
+    zipCode: '',
+    phone: '',
+  },
+  payment: {
+    nameOnCard: '',
+    cardNumber: '',
+    expirationMonth: '',
+    expirationYear: '',
+    securityCode: '',
+    email: '',
+    profileName: '',
+  }
+}
+
+const BillingProfileFactory = (): BillingProfile => {
+  return {
+    ...template,
+    billing: {
+      ...template.billing
+    },
+    shipping: {
+      ...template.shipping
+    },
+    payment: {
+      ...template.payment
+    }
+  }
+}
+
+export default BillingProfileFactory

--- a/src/mockData/billingProfiles.ts
+++ b/src/mockData/billingProfiles.ts
@@ -29,7 +29,7 @@ const generateBillingProfiles = (amount: number = 10) => {
       nameOnCard: `${firstName} ${lastName}`,
       cardNumber: creditCards[Math.floor(Math.random() * Math.floor(3))],
       expirationMonth: '12',
-      expirationYear: '24',
+      expirationYear: '2024',
       securityCode: '342',
       email: faker.internet.email(),
       profileName: faker.internet.userName(),

--- a/src/store/billingProfiles/reducer.ts
+++ b/src/store/billingProfiles/reducer.ts
@@ -32,7 +32,7 @@ const billingProfilesReducer = (state = initialState, action: BillingProfileActi
     case DELETE_PROFILE:
       const filteredBillingProfiles = state.profiles.filter(profile => profile.id !== action.id)
       return {
-        currentId: filteredBillingProfiles.length > 0 ? filteredBillingProfiles[filteredBillingProfiles.length - 1].id : '',
+        currentId: filteredBillingProfiles.length > 0 ? filteredBillingProfiles[0].id : '',
         profiles: filteredBillingProfiles
       }
     case CHANGE_PROFILE:

--- a/src/store/billingProfiles/thunks.ts
+++ b/src/store/billingProfiles/thunks.ts
@@ -1,8 +1,10 @@
 import { ThunkAction, ThunkDispatch } from 'redux-thunk'
 import { Action } from 'redux'
+import { v4 as uuidv4 } from 'uuid'
 
 import { RootState } from '../index'
 import { BillingProfile } from '@typesTS/billingTypes'
+import BillingProfileFactory from '../../factory/BillingProfile'
 import generateBillingProfiles from '../../mockData/billingProfiles'
 import {
   populateProfiles,
@@ -14,27 +16,37 @@ import {
 export const fetchProfiles = (): ThunkAction<void, RootState, unknown, Action<string>> => { // Action<string> where string is the type of the key:value property of 'type'
   return async dispatch => {
     const payload = generateBillingProfiles()
-    dispatch(populateProfiles(payload))
+    if (payload.length === 0) { // if there are no profiles, create one automatically
+      dispatch(createBillingProfile())
+    } else {
+      dispatch(populateProfiles(payload))
+    }
   }
 }
 
-export const createBillingProfile = (newProfile: BillingProfile): ThunkAction<void, RootState, unknown, Action<string>> => {
+export const createBillingProfile = (): ThunkAction<void, RootState, unknown, Action<string>> => {
   return async dispatch => {
     // TODO: add new profile to file
-    // dispatch(createProfile())
+    const newProfile = BillingProfileFactory()
+    newProfile.id = uuidv4()
+    dispatch(createProfile(newProfile))
   }
 }
 
 export const updateBillingProfile = (userProfile: BillingProfile): ThunkAction<void, RootState, unknown, Action<string>> => {
   return async dispatch => {
     // TODO: update the profiles file
-    // dispatch(updateProfile())
+    dispatch(updateProfile(userProfile))
   }
 }
 
 export const deleteBillingProfile = (id: string): ThunkAction<void, RootState, unknown, Action<string>> => {
-  return async dispatch => {
-    // TODO: 
-    // dispatch(deleteProfile())
+  return async (dispatch, getState) => {
+    // Run file update 
+    dispatch(deleteProfile(id))
+    const { billingProfiles } = getState()
+    if (billingProfiles.profiles.length === 0) { // if all profiles are gone, create one
+      dispatch(createBillingProfile())
+    }
   }
 }

--- a/src/store/billingProfiles/thunks.ts
+++ b/src/store/billingProfiles/thunks.ts
@@ -28,7 +28,6 @@ export const createBillingProfile = (): ThunkAction<void, RootState, unknown, Ac
   return async dispatch => {
     // TODO: add new profile to file
     const newProfile = BillingProfileFactory()
-    newProfile.id = uuidv4()
     dispatch(createProfile(newProfile))
   }
 }

--- a/src/types/billingTypes.ts
+++ b/src/types/billingTypes.ts
@@ -24,7 +24,9 @@ export interface PaymentInfo {
 
 export type BillingProfile = {
   id: string,
+  billingSameAsShipping: boolean,
   billing: UserInfo,
   shipping: UserInfo,
   payment: PaymentInfo
+  [index: string]: string | boolean | UserInfo | PaymentInfo // assuming that '[index: string]' is defining the type of the index and the following are the possible values of that key (need to look up)
 }


### PR DESCRIPTION
User can
 - edit a profile and save it to memory
- delete a profile
- create a new profile

Dev notes:
- gave the BillingProfile a `billingSameAsShipping` key and removed the `useState` call in the BillingView for it. I believe we'll be using that key within the profile when we make requests to `enter random shopping site here` when users bot them 