### PR TITLE
Billing profiles/add edit button functionality

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -15,8 +15,6 @@ input::placeholder {
 }
 
 .overlay {
-  height: 450px;
-  width: inherit;
   z-index: 10;
   @apply absolute opacity-25 bg-black-netflix rounded;
 }

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -11,7 +11,7 @@ import { setUpAppStartUpListeners, setUpOperationIndicators, teardownOperationsI
 const Main = () => {
   useEffect(() => {
     // componentDidMount 
-    setUpAppStartUpListeners() // used for initial data fetch, subsription is automatically unsubbed
+    setUpAppStartUpListeners() // used for initial data fetch, subscription is automatically unsubbed
     setUpOperationIndicators() // used to listen to successful operations and bad operations to display err messages to frontend & cancel the loading
 
     emitStartUpDataRequest()

--- a/src/components/billing/BillingView.tsx
+++ b/src/components/billing/BillingView.tsx
@@ -33,7 +33,7 @@ import { updateBillingProfile, deleteBillingProfile, createProfile } from '../..
 const BillingView: FunctionComponent = () => {
   const [store, dispatch] = useReducer(billingProfileReducer, initialBillingStore)
   const [inputErrors, dispatchErrors] = useReducer(inputFieldErrorsReducer, initialInputErrorStore)
-  const [editable, dispatchEditable] = useState(false)
+  const [editable, setEditable] = useState(false)
   const rootDispatch = useDispatch()
 
   const currentProfileData = useSelector((state: RootState) => {
@@ -51,7 +51,7 @@ const BillingView: FunctionComponent = () => {
     dispatchErrors({
       type: CLEAR_INPUT_FIELD_ERRORS_ALL
     })
-    dispatchEditable(false)
+    setEditable(false)
   }, [currentProfileData.currentId])
 
   const toggleBillingMatchShipping = () => {
@@ -62,7 +62,7 @@ const BillingView: FunctionComponent = () => {
 
   const toggleEditable = () => {
     // TODO: workflow: If user hits the lock button, run saveProfile function; check for errors, if error prevent the lock and keep the profile in edit mode and have user fix profile until error is resolved?
-    dispatchEditable(!editable)
+    setEditable(!editable)
   }
 
   const saveProfile = () => {
@@ -145,16 +145,16 @@ const BillingView: FunctionComponent = () => {
             <AppButton onClick={() => rootDispatch(createProfile())} btnName='New' classes='btn-gray w-20 ml-6' />
           </div>
         </div>
-        <UserDetails name='Billing Address' userDetails={store.billing} errors={inputErrors.billing} dispatch={dispatch} onChangeActionType={UPDATE_BILLING_KEY} editable={editable} />
+        <UserDetails name='Billing Address' userDetails={store.billing} errors={inputErrors.billing} dispatch={dispatch} onChangeActionType={UPDATE_BILLING_KEY} disableInput={!editable} />
         <div>
-          <UserDetails name='Shipping Address' userDetails={store.shipping} errors={inputErrors.shipping} dispatch={dispatch} onChangeActionType={UPDATE_SHIPPING_KEY} billingSameAsShipping={store.billingSameAsShipping} editable={editable} />
+          <UserDetails name='Shipping Address' userDetails={store.shipping} errors={inputErrors.shipping} dispatch={dispatch} onChangeActionType={UPDATE_SHIPPING_KEY} disableInput={!editable || store.billingSameAsShipping} />
           <div>
             <input className='ml-8 mr-1' type='checkbox' name='Same as Billing Address' onChange={toggleBillingMatchShipping} checked={store.billingSameAsShipping} disabled={!editable} />
             <label className='text-white'>Same as Billing Address</label>
           </div>
         </div>
         <div className='w-80 mx-6'>
-          <PaymentDetails paymentDetails={store.payment} errors={inputErrors.payment} dispatch={dispatch} editable={editable} />
+          <PaymentDetails paymentDetails={store.payment} errors={inputErrors.payment} dispatch={dispatch} disableInput={!editable} />
           <div className='flex justify-center mt-6'>
             <AppButton onClick={saveProfile} btnName='Save' classes='btn-gray mr-8 w-20' />
             <AppButton onClick={() => rootDispatch(deleteBillingProfile(currentProfileData.currentId))} btnName='Delete' classes='btn-gray w-20' />

--- a/src/components/billing/BillingView.tsx
+++ b/src/components/billing/BillingView.tsx
@@ -65,7 +65,7 @@ const BillingView: FunctionComponent = () => {
     dispatchEditable(!editable)
   }
 
-  function saveProfile() {
+  const saveProfile = () => {
     const userInfoValidationKeys = Object.keys(userInfoValidation)
     const paymentInfoValidationKeys = Object.keys(paymentInfoValidation)
     let areThereErrors = false
@@ -145,9 +145,9 @@ const BillingView: FunctionComponent = () => {
             <AppButton onClick={() => rootDispatch(createProfile())} btnName='New' classes='btn-gray w-20 ml-6' />
           </div>
         </div>
-        <UserDetails name='Billing View' userDetails={store.billing} errors={inputErrors.billing} dispatch={dispatch} onChangeActionType={UPDATE_BILLING_KEY} editable={editable} />
+        <UserDetails name='Billing Address' userDetails={store.billing} errors={inputErrors.billing} dispatch={dispatch} onChangeActionType={UPDATE_BILLING_KEY} editable={editable} />
         <div>
-          <UserDetails name='Shipping View' userDetails={store.shipping} errors={inputErrors.shipping} dispatch={dispatch} onChangeActionType={UPDATE_SHIPPING_KEY} billingSameAsShipping={store.billingSameAsShipping} editable={editable} />
+          <UserDetails name='Shipping Address' userDetails={store.shipping} errors={inputErrors.shipping} dispatch={dispatch} onChangeActionType={UPDATE_SHIPPING_KEY} billingSameAsShipping={store.billingSameAsShipping} editable={editable} />
           <div>
             <input className='ml-8 mr-1' type='checkbox' name='Same as Billing Address' onChange={toggleBillingMatchShipping} checked={store.billingSameAsShipping} disabled={!editable} />
             <label className='text-white'>Same as Billing Address</label>

--- a/src/components/billing/details/PaymentDetails.tsx
+++ b/src/components/billing/details/PaymentDetails.tsx
@@ -10,11 +10,11 @@ import Overlay from '../../common/Overlay'
 type PaymentDetailsProps = {
   paymentDetails: PaymentInfo,
   errors: PaymentInfo,
-  editable: boolean,
+  disableInput: boolean,
   dispatch: React.Dispatch<StoreAction>
 }
 
-const PaymentDetails: FunctionComponent<PaymentDetailsProps> = ({ paymentDetails, editable, dispatch, errors }) => {
+const PaymentDetails: FunctionComponent<PaymentDetailsProps> = ({ paymentDetails, disableInput, dispatch, errors }) => {
   const { nameOnCard, cardNumber, expirationMonth, expirationYear, securityCode, email, profileName } = paymentDetails
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>): void => dispatch({
@@ -28,18 +28,18 @@ const PaymentDetails: FunctionComponent<PaymentDetailsProps> = ({ paymentDetails
       <div className='bg-gray-850 text-center text-xl w-2/3 mb-2'>
         <h4 className='text-white'>Payment Details</h4>
       </div>
-      {!editable ? <Overlay styles={{ height: '450px' }} classes='w-80' /> : null}}
+      {disableInput ? <Overlay styles={{ height: '450px' }} classes='w-80' /> : null}
       <div className='flex flex-col'>
         {/*TODO: ENUM here for card type*/}
         <FormInput type='text' name='cardNumber' placeholder='Credit Card Number' value={cardNumber} onChange={onChange} maxLength={19} error={errors.cardNumber} classes={'my-1'} />
         <div className='my-1 flex justify-center'>
-          <FormInput type='text' name='expirationMonth' placeholder='Month' value={expirationMonth} onChange={onChange} error={errors.expirationMonth} maxLength={4} size={5} classes={'flex-grow'} disabled={!editable} />
-          <FormInput type='text' name='expirationYear' placeholder='Year' value={expirationYear} onChange={onChange} error={errors.expirationYear} maxLength={4} size={5} classes={'mx-1 flex-grow'} disabled={!editable} />
-          <FormInput type='text' name='securityCode' placeholder='CVV' value={securityCode} onChange={onChange} error={errors.securityCode} maxLength={4} size={5} classes={'flex-grow'} disabled={!editable} />
+          <FormInput type='text' name='expirationMonth' placeholder='Month' value={expirationMonth} onChange={onChange} error={errors.expirationMonth} maxLength={4} size={5} classes={'flex-grow'} disabled={disableInput} />
+          <FormInput type='text' name='expirationYear' placeholder='Year' value={expirationYear} onChange={onChange} error={errors.expirationYear} maxLength={4} size={5} classes={'mx-1 flex-grow'} disabled={disableInput} />
+          <FormInput type='text' name='securityCode' placeholder='CVV' value={securityCode} onChange={onChange} error={errors.securityCode} maxLength={4} size={5} classes={'flex-grow'} disabled={disableInput} />
         </div>
-        <FormInput type='text' name='nameOnCard' placeholder='Full Name' value={nameOnCard} onChange={onChange} error={errors.nameOnCard} classes={'my-1'} disabled={!editable} />
-        <FormInput type='text' name='email' placeholder='Email' value={email} onChange={onChange} error={errors.email} classes={'my-1'} disabled={!editable} />
-        <FormInput type='text' name='profileName' placeholder='Profile Name' value={profileName} onChange={onChange} error={errors.profileName} classes={'my-1'} disabled={!editable} />
+        <FormInput type='text' name='nameOnCard' placeholder='Full Name' value={nameOnCard} onChange={onChange} error={errors.nameOnCard} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='email' placeholder='Email' value={email} onChange={onChange} error={errors.email} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='profileName' placeholder='Profile Name' value={profileName} onChange={onChange} error={errors.profileName} classes={'my-1'} disabled={disableInput} />
       </div>
     </div>
   )

--- a/src/components/billing/details/PaymentDetails.tsx
+++ b/src/components/billing/details/PaymentDetails.tsx
@@ -5,14 +5,16 @@ import { StoreAction } from '../store/types'
 import { UPDATE_PAYMENT_KEY } from '../store/actions'
 
 import FormInput from '../../common/FormInput'
+import Overlay from '../../common/Overlay'
 
 type PaymentDetailsProps = {
   paymentDetails: PaymentInfo,
   errors: PaymentInfo,
+  editable: boolean,
   dispatch: React.Dispatch<StoreAction>
 }
 
-const PaymentDetails: FunctionComponent<PaymentDetailsProps> = ({ paymentDetails, dispatch, errors }) => {
+const PaymentDetails: FunctionComponent<PaymentDetailsProps> = ({ paymentDetails, editable, dispatch, errors }) => {
   const { nameOnCard, cardNumber, expirationMonth, expirationYear, securityCode, email, profileName } = paymentDetails
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>): void => dispatch({
@@ -26,17 +28,18 @@ const PaymentDetails: FunctionComponent<PaymentDetailsProps> = ({ paymentDetails
       <div className='bg-gray-850 text-center text-xl w-2/3 mb-2'>
         <h4 className='text-white'>Payment Details</h4>
       </div>
+      {!editable ? <Overlay styles={{ height: '450px' }} classes='w-80' /> : null}}
       <div className='flex flex-col'>
         {/*TODO: ENUM here for card type*/}
         <FormInput type='text' name='cardNumber' placeholder='Credit Card Number' value={cardNumber} onChange={onChange} maxLength={19} error={errors.cardNumber} classes={'my-1'} />
         <div className='my-1 flex justify-center'>
-          <FormInput type='text' name='expirationMonth' placeholder='Month' value={expirationMonth} onChange={onChange} error={errors.expirationMonth} maxLength={4} size={5} classes={'flex-grow'} />
-          <FormInput type='text' name='expirationYear' placeholder='Year' value={expirationYear} onChange={onChange} error={errors.expirationYear} maxLength={4} size={5} classes={'mx-1 flex-grow'} />
-          <FormInput type='text' name='securityCode' placeholder='CVV' value={securityCode} onChange={onChange} error={errors.securityCode} maxLength={4} size={5} classes={'flex-grow'} />
+          <FormInput type='text' name='expirationMonth' placeholder='Month' value={expirationMonth} onChange={onChange} error={errors.expirationMonth} maxLength={4} size={5} classes={'flex-grow'} disabled={!editable} />
+          <FormInput type='text' name='expirationYear' placeholder='Year' value={expirationYear} onChange={onChange} error={errors.expirationYear} maxLength={4} size={5} classes={'mx-1 flex-grow'} disabled={!editable} />
+          <FormInput type='text' name='securityCode' placeholder='CVV' value={securityCode} onChange={onChange} error={errors.securityCode} maxLength={4} size={5} classes={'flex-grow'} disabled={!editable} />
         </div>
-        <FormInput type='text' name='nameOnCard' placeholder='Full Name' value={nameOnCard} onChange={onChange} error={errors.nameOnCard} classes={'my-1'} />
-        <FormInput type='text' name='email' placeholder='Email' value={email} onChange={onChange} error={errors.email} classes={'my-1'} />
-        <FormInput type='text' name='profileName' placeholder='Profile Name' value={profileName} onChange={onChange} error={errors.profileName} classes={'my-1'} />
+        <FormInput type='text' name='nameOnCard' placeholder='Full Name' value={nameOnCard} onChange={onChange} error={errors.nameOnCard} classes={'my-1'} disabled={!editable} />
+        <FormInput type='text' name='email' placeholder='Email' value={email} onChange={onChange} error={errors.email} classes={'my-1'} disabled={!editable} />
+        <FormInput type='text' name='profileName' placeholder='Profile Name' value={profileName} onChange={onChange} error={errors.profileName} classes={'my-1'} disabled={!editable} />
       </div>
     </div>
   )

--- a/src/components/billing/details/UserDetails.tsx
+++ b/src/components/billing/details/UserDetails.tsx
@@ -9,12 +9,11 @@ type UserDetailsProps = {
   name: string,
   errors: UserInfo,
   onChangeActionType: string,
-  billingSameAsShipping?: boolean, // ? makes billingSameAsShipping an optional prop
-  editable: boolean,
+  disableInput: boolean,
   dispatch: React.Dispatch<StoreAction>
 }
 
-const UserDetails: FunctionComponent<UserDetailsProps> = ({ userDetails, name, dispatch, errors, billingSameAsShipping, editable, onChangeActionType }) => {
+const UserDetails: FunctionComponent<UserDetailsProps> = ({ userDetails, name, dispatch, errors, disableInput, onChangeActionType }) => {
   const { firstName, lastName, address1, address2, city, state, country, zipCode, phone } = userDetails
 
   const onChange = (e: ChangeEvent<HTMLInputElement>): void => dispatch({
@@ -28,17 +27,17 @@ const UserDetails: FunctionComponent<UserDetailsProps> = ({ userDetails, name, d
       <div className='bg-gray-850 text-center text-xl w-2/3 mb-2'>
         <h4 className='text-white'>{name}</h4>
       </div>
-      {billingSameAsShipping || !editable ? <Overlay styles={{ height: '450px' }} classes='w-inherit' /> : null}
+      {disableInput ? <Overlay styles={{ height: '450px' }} classes='w-inherit' /> : null}
       <div className='flex flex-col'>
-        <FormInput type='text' name='firstName' placeholder='First Name' value={firstName} onChange={onChange} error={errors.firstName} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='lastName' placeholder='Last Name' value={lastName} onChange={onChange} error={errors.lastName} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='address1' placeholder='Address 1' value={address1} onChange={onChange} error={errors.address1} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='address2' placeholder='Address 2' value={address2} onChange={onChange} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='city' placeholder='City' value={city} onChange={onChange} error={errors.city} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='state' placeholder='State' value={state} onChange={onChange} error={errors.state} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='country' placeholder='Country' value={country} onChange={onChange} error={errors.country} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='zipCode' placeholder='Zip Code' value={zipCode} onChange={onChange} error={errors.zipCode} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
-        <FormInput type='text' name='phone' placeholder='Phone' value={phone} onChange={onChange} error={errors.phone} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='firstName' placeholder='First Name' value={firstName} onChange={onChange} error={errors.firstName} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='lastName' placeholder='Last Name' value={lastName} onChange={onChange} error={errors.lastName} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='address1' placeholder='Address 1' value={address1} onChange={onChange} error={errors.address1} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='address2' placeholder='Address 2' value={address2} onChange={onChange} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='city' placeholder='City' value={city} onChange={onChange} error={errors.city} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='state' placeholder='State' value={state} onChange={onChange} error={errors.state} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='country' placeholder='Country' value={country} onChange={onChange} error={errors.country} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='zipCode' placeholder='Zip Code' value={zipCode} onChange={onChange} error={errors.zipCode} classes={'my-1'} disabled={disableInput} />
+        <FormInput type='text' name='phone' placeholder='Phone' value={phone} onChange={onChange} error={errors.phone} classes={'my-1'} disabled={disableInput} />
       </div>
     </div>
   );

--- a/src/components/billing/details/UserDetails.tsx
+++ b/src/components/billing/details/UserDetails.tsx
@@ -10,10 +10,11 @@ type UserDetailsProps = {
   errors: UserInfo,
   onChangeActionType: string,
   billingSameAsShipping?: boolean, // ? makes billingSameAsShipping an optional prop
+  editable: boolean,
   dispatch: React.Dispatch<StoreAction>
 }
 
-const UserDetails: FunctionComponent<UserDetailsProps> = ({ userDetails, name, dispatch, errors, billingSameAsShipping, onChangeActionType }) => {
+const UserDetails: FunctionComponent<UserDetailsProps> = ({ userDetails, name, dispatch, errors, billingSameAsShipping, editable, onChangeActionType }) => {
   const { firstName, lastName, address1, address2, city, state, country, zipCode, phone } = userDetails
 
   const onChange = (e: ChangeEvent<HTMLInputElement>): void => dispatch({
@@ -27,17 +28,17 @@ const UserDetails: FunctionComponent<UserDetailsProps> = ({ userDetails, name, d
       <div className='bg-gray-850 text-center text-xl w-2/3 mb-2'>
         <h4 className='text-white'>{name}</h4>
       </div>
-      {billingSameAsShipping ? <Overlay /> : null}
+      {billingSameAsShipping || !editable ? <Overlay styles={{ height: '450px' }} classes='w-inherit' /> : null}
       <div className='flex flex-col'>
-        <FormInput type='text' name='firstName' placeholder='First Name' value={firstName} onChange={onChange} error={errors.firstName} classes={'my-1'} />
-        <FormInput type='text' name='lastName' placeholder='Last Name' value={lastName} onChange={onChange} error={errors.lastName} classes={'my-1'} />
-        <FormInput type='text' name='address1' placeholder='Address 1' value={address1} onChange={onChange} error={errors.address1} classes={'my-1'} />
-        <FormInput type='text' name='address2' placeholder='Address 2' value={address2} onChange={onChange} classes={'my-1'} />
-        <FormInput type='text' name='city' placeholder='City' value={city} onChange={onChange} error={errors.city} classes={'my-1'} />
-        <FormInput type='text' name='state' placeholder='State' value={state} onChange={onChange} error={errors.state} classes={'my-1'} />
-        <FormInput type='text' name='country' placeholder='Country' value={country} onChange={onChange} error={errors.country} classes={'my-1'} />
-        <FormInput type='text' name='zipCode' placeholder='Zip Code' value={zipCode} onChange={onChange} error={errors.zipCode} classes={'my-1'} />
-        <FormInput type='text' name='phone' placeholder='Phone' value={phone} onChange={onChange} error={errors.phone} classes={'my-1'} />
+        <FormInput type='text' name='firstName' placeholder='First Name' value={firstName} onChange={onChange} error={errors.firstName} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='lastName' placeholder='Last Name' value={lastName} onChange={onChange} error={errors.lastName} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='address1' placeholder='Address 1' value={address1} onChange={onChange} error={errors.address1} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='address2' placeholder='Address 2' value={address2} onChange={onChange} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='city' placeholder='City' value={city} onChange={onChange} error={errors.city} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='state' placeholder='State' value={state} onChange={onChange} error={errors.state} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='country' placeholder='Country' value={country} onChange={onChange} error={errors.country} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='zipCode' placeholder='Zip Code' value={zipCode} onChange={onChange} error={errors.zipCode} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
+        <FormInput type='text' name='phone' placeholder='Phone' value={phone} onChange={onChange} error={errors.phone} classes={'my-1'} disabled={billingSameAsShipping || !editable} />
       </div>
     </div>
   );

--- a/src/components/common/FormInput.tsx
+++ b/src/components/common/FormInput.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, ChangeEvent, Fragment } from 'react'
 
-type FormTextProps = {
+type FormInputProps = {
   onChange: (e: ChangeEvent<HTMLElement>) => void,
   type: string,
   name: string,
@@ -13,7 +13,7 @@ type FormTextProps = {
   classes?: string,// classes (additional classes that modifies adds onto the default classes (maybe more margin or padding)?)
 }
 
-const FormText: FunctionComponent<FormTextProps> = ({ type, name, placeholder, value, disabled, error, onChange, maxLength, size, classes }) => {
+const FormInput: FunctionComponent<FormInputProps> = ({ type, name, placeholder, value, disabled, error, onChange, maxLength, size, classes }) => {
   return (
     <Fragment>
       <input
@@ -32,12 +32,12 @@ const FormText: FunctionComponent<FormTextProps> = ({ type, name, placeholder, v
   )
 }
 
-FormText.defaultProps = {
+FormInput.defaultProps = {
   maxLength: 50,
   size: 20,
   disabled: false,
   classes: '',
   error: ''
-} as Partial<FormTextProps>
+} as Partial<FormInputProps>
 
-export default FormText
+export default FormInput

--- a/src/components/common/Overlay.tsx
+++ b/src/components/common/Overlay.tsx
@@ -1,7 +1,17 @@
 import React, { FunctionComponent } from 'react'
 
-const Overlay: FunctionComponent = () => {
-  return <div className='overlay'></div>
+type OverlayProps = {
+  classes?: string,
+  styles?: any // style objects in case we want to hard card a specific height, etc.
+}
+
+const Overlay: FunctionComponent<OverlayProps> = ({ styles, classes }) => {
+  return <div className={`overlay ${classes}`} style={styles} ></div >
+}
+
+Overlay.defaultProps = {
+  styles: {},
+  classes: ''
 }
 
 export default Overlay

--- a/src/store/billingProfiles/actions.ts
+++ b/src/store/billingProfiles/actions.ts
@@ -1,5 +1,5 @@
 import { Action, ActionCreator } from 'redux'
-import { ThunkAction, ThunkDispatch } from 'redux-thunk'
+import { ThunkAction } from 'redux-thunk'
 
 import { FETCH_PROFILES, UPDATE_PROFILE, CREATE_PROFILE, DELETE_PROFILE, CHANGE_PROFILE } from './types'
 import { BillingProfile } from '@typesTS/billingTypes'
@@ -36,13 +36,8 @@ export const changeProfile: ActionCreator<Action> = (newId: string) => ({
 // thunks 
 export const deleteBillingProfile = (id: string): ThunkAction<void, RootState, unknown, Action<string>> => {
   emitDeleteProfile(id)
-  return (dispatch, getState) => {
+  return (dispatch) => { // TODO: add event listener to lsiten for a deleteProfileSuccessEvent and then remove profile front FE? Same for the updateBillingProfile function below (might remove these thunks from billingProfile; doesn't seem to be needed anymore)
     dispatch(deleteProfile(id))
-
-    const { billingProfiles } = getState()
-    if (billingProfiles.profiles.length === 0) {
-      dispatch(createProfile())
-    }
   }
 }
 

--- a/src/store/billingProfiles/reducer.ts
+++ b/src/store/billingProfiles/reducer.ts
@@ -1,4 +1,5 @@
 import { BillingProfileActionTypes, BillingProfileState, FETCH_PROFILES, UPDATE_PROFILE, CREATE_PROFILE, DELETE_PROFILE, CHANGE_PROFILE } from './types'
+import BillingProfileFactory from '../../factory/BillingProfile'
 
 const initialState: BillingProfileState = {
   profiles: [],
@@ -8,9 +9,17 @@ const initialState: BillingProfileState = {
 const billingProfilesReducer = (state = initialState, action: BillingProfileActionTypes): BillingProfileState => {
   switch (action.type) {
     case FETCH_PROFILES:
-      return {
-        currentId: action.payload.length > 0 ? action.payload[0].id : '',
-        profiles: action.payload
+      if (action.payload.length >= 1) {
+        return {
+          currentId: action.payload[0].id,
+          profiles: action.payload
+        }
+      } else { // if user doesn't have any billing profiles saved, generate an instance of it for them 
+        const emptyBillingProfile = BillingProfileFactory()
+        return {
+          currentId: emptyBillingProfile.id,
+          profiles: [emptyBillingProfile]
+        }
       }
     case UPDATE_PROFILE:
       return {
@@ -30,9 +39,12 @@ const billingProfilesReducer = (state = initialState, action: BillingProfileActi
         profiles: [action.payload, ...state.profiles]
       }
     case DELETE_PROFILE:
-      const filteredBillingProfiles = state.profiles.filter(profile => profile.id !== action.id)
+      const filteredBillingProfiles = state.profiles.filter(profile => profile.id !== action.id) // if deleted profile was the last one, generate an empty for user
+      if (filteredBillingProfiles.length === 0) {
+        filteredBillingProfiles.push(BillingProfileFactory())
+      }
       return {
-        currentId: filteredBillingProfiles.length > 0 ? filteredBillingProfiles[0].id : '',
+        currentId: filteredBillingProfiles[0].id,
         profiles: filteredBillingProfiles
       }
     case CHANGE_PROFILE:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -414,6 +414,7 @@ module.exports = {
       '11/12': '91.666667%',
       full: '100%',
       screen: '100vw',
+      inherit: 'inherit'
     }),
     zIndex: {
       auto: 'auto',


### PR DESCRIPTION
Overview (back in the game)
- fixed bug in which fetching existing profiles with `billingSameAsShipping` set to true will not be correctly linked with the input checkbox
- added functionality for the `Edit` button in billing profiles
- removed old comments 
- removed if no profile, then create one logic from thunks to the actual reducer. (not sure if we need thunks) 